### PR TITLE
Handle missing session data for case grid

### DIFF
--- a/dhHelpdeskNG/dhHelpdesk_NG.Web/Controllers/CasesController.cs
+++ b/dhHelpdeskNG/dhHelpdesk_NG.Web/Controllers/CasesController.cs
@@ -609,6 +609,16 @@ namespace DH.Helpdesk.Web.Controllers
             m.CaseInputViewModel = this.PopulateBulkCaseEditModal(m.CaseSetting.CustomerId);
             var user = _userService.GetUser(userId);
 
+            if (SessionFacade.CaseOverviewGridSettings.pageOptions == null)
+            {
+                SessionFacade.CaseOverviewGridSettings.pageOptions = new GridPageOptions();
+            }
+
+            if (SessionFacade.CurrentCaseSearch.CaseSearchFilter.PageInfo == null)
+            {
+                SessionFacade.CurrentCaseSearch.CaseSearchFilter.PageInfo = new PageInfo();
+            }
+
             SessionFacade.CaseOverviewGridSettings.pageOptions.pageIndex =
                 SessionFacade.CurrentCaseSearch.CaseSearchFilter.PageInfo.PageNumber;
 


### PR DESCRIPTION
## Summary
- guard against missing `pageOptions` and `PageInfo` in `CasesController.Index`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849887b6584832ab2a0f58a766d01ed